### PR TITLE
Support multiple layouts, changing to match `group` send by compositor

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -46,11 +46,21 @@ pub struct Layout {
     pub layers: Vec<Layer>,
 }
 
-impl From<&xkb::Keymap> for Layout {
-    fn from(keymap: &xkb::Keymap) -> Self {
+impl Layout {
+    pub fn all(keymap: &xkb::Keymap) -> Option<Vec<Self>> {
         if keymap.num_layouts() == 0 {
-            return Layout::default();
+            None
+        } else {
+            Some(
+                (0..keymap.num_layouts())
+                    .map(|layout| Self::new(keymap, layout))
+                    .collect(),
+            )
         }
+    }
+
+    fn new(keymap: &xkb::Keymap, layout: u32) -> Self {
+        assert!(keymap.num_layouts() > layout);
 
         let key_rows: &'static [&'static [&'static str]] = &[
             &[
@@ -129,7 +139,7 @@ impl From<&xkb::Keymap> for Layout {
                         normal_key.keycode = Some(KeyCode(kc));
                         shift_key.keycode = Some(KeyCode(kc));
 
-                        let normal_syms = keymap.key_get_syms_by_level(kc, 0, 0);
+                        let normal_syms = keymap.key_get_syms_by_level(kc, layout, 0);
                         if let Some(normal_sym) = normal_syms.get(0) {
                             normal_key.name = xkb::keysym_get_name(*normal_sym);
                             if let Some(normal_char) = normal_sym.key_char() {
@@ -142,7 +152,7 @@ impl From<&xkb::Keymap> for Layout {
                             shift_key.name = normal_key.name.clone();
                         }
 
-                        let shift_syms = keymap.key_get_syms_by_level(kc, 0, 1);
+                        let shift_syms = keymap.key_get_syms_by_level(kc, layout, 1);
                         if let Some(shift_sym) = shift_syms.get(0) {
                             shift_key.name = xkb::keysym_get_name(*shift_sym);
                             if let Some(shift_char) = shift_sym.key_char() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,8 @@ pub struct App {
     config: Config,
     key_padding: usize,
     key_size: usize,
-    layout: Option<Layout>,
+    layouts: Option<Vec<Layout>>,
+    group: u32,
     layer: usize,
     sticky: HashSet<layout::KeyCode>,
     surface_id: Option<WindowId>,
@@ -130,7 +131,8 @@ impl Application for App {
             key_padding: 4,
             key_size: 64,
             layer: 0,
-            layout: None,
+            layouts: None,
+            group: 0,
             sticky: HashSet::new(),
             surface_id: None,
             xkb_state: None,
@@ -226,7 +228,6 @@ impl Application for App {
             }
             Message::Ei(evt) => {
                 match evt {
-                    // TODO handle modifiers
                     ei::Msg::Connection(conn) => {
                         self.ei_conn = Some(conn);
                     }
@@ -256,16 +257,19 @@ impl Application for App {
                             .unwrap()
                             .unwrap()
                         };
-                        let layout = Layout::from(&xkb_keymap);
+                        let layouts =
+                            Layout::all(&xkb_keymap).unwrap_or_else(|| vec![Layout::default()]);
 
                         let mut height = 0;
-                        for layer in layout.layers.iter() {
-                            height = height
-                                .max((self.key_size + self.key_padding * 2) * layer.rows.len());
+                        for layout in &layouts {
+                            for layer in layout.layers.iter() {
+                                height = height
+                                    .max((self.key_size + self.key_padding * 2) * layer.rows.len());
+                            }
                         }
 
                         self.layer = 0;
-                        self.layout = Some(layout);
+                        self.layouts = Some(layouts);
                         self.xkb_state = Some(xkb::State::new(&xkb_keymap));
 
                         //TODO: destroy and recreate surface when layout changes?
@@ -294,6 +298,10 @@ impl Application for App {
                             });
                         }
                     }
+                    // TODO handle other modifiers
+                    ei::Msg::Event(reis::event::EiEvent::KeyboardModifiers(evt)) => {
+                        self.group = evt.group;
+                    }
                     _ => {}
                 }
             }
@@ -315,9 +323,9 @@ impl Application for App {
         } = theme::spacing();
 
         let element: Element<_> = if let Some(layout_layer) = self
-            .layout
+            .layouts
             .as_ref()
-            .and_then(|layout| layout.layers.get(self.layer))
+            .and_then(|layouts| layouts.get(self.group as usize)?.layers.get(self.layer))
         {
             let mut grid = widget::column::with_capacity(layout_layer.rows.len() + 1);
             grid = grid.push(widget::row::with_children(vec![


### PR DESCRIPTION
We should probably add a button to change the layout using `cosmic-keyboard-layout-unstable-v1`. And we need to handle shift/caps in some way, and support more than 2 layers for layouts where that is important. I'll look into some of those things later, but this is a good incremental improvement.

Oddly it seems cosmic-comp's libei is sending `modifers` only after a super+space keybinding is released, while the applet gets the new group through `cosmic-keyboard-layout-unstable-v1` immediately...