### PR TITLE
Caps lock visual symbols

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -88,11 +88,25 @@ impl Layout {
             ],
         ];
 
+        // Create scratch xkb_state and update mask for Caps lock.
+        // This allows querying keysyms as if Caps lock is pressed.
+        let mut xkb_state_caps = xkb::State::new(keymap);
+        let caps_mask_filter = keymap
+            .mods()
+            .into_iter()
+            .filter(|v| *v == "Lock")
+            .collect::<Vec<&str>>();
+        let lock_modifier_name = caps_mask_filter.first();
+        let caps_mask = keymap.mod_get_index(lock_modifier_name.expect("Lock modifier should be present for keymap"));
+        xkb_state_caps.update_mask(0, 0, 1 << caps_mask, 0, 0, 0);
+
         let mut normal_layer = Layer::default();
         let mut shift_layer = Layer::default();
+        let mut caps_layer = Layer::default();
         for key_row in key_rows.iter() {
             let mut normal_row = Vec::with_capacity(key_row.len());
             let mut shift_row = Vec::with_capacity(key_row.len());
+            let mut caps_row = Vec::with_capacity(key_row.len());
             for &key in key_row.iter() {
                 let kind = match key {
                     // Press these modifiers until a normal key is pressed
@@ -133,11 +147,18 @@ impl Layout {
                     width: 1.0,
                     keycode: None,
                 };
+                let mut caps_key = Key {
+                    name: key.to_string(),
+                    kind,
+                    width: 1.0,
+                    keycode: None,
+                };
 
                 match keymap.key_by_name(key) {
                     Some(kc) => {
                         normal_key.keycode = Some(KeyCode(kc));
                         shift_key.keycode = Some(KeyCode(kc));
+                        caps_key.keycode = Some(KeyCode(kc));
 
                         let normal_syms = keymap.key_get_syms_by_level(kc, layout, 0);
                         if let Some(normal_sym) = normal_syms.get(0) {
@@ -150,6 +171,7 @@ impl Layout {
 
                             // Copy normal key name over by default
                             shift_key.name = normal_key.name.clone();
+                            caps_key.name = normal_key.name.clone();
                         }
 
                         let shift_syms = keymap.key_get_syms_by_level(kc, layout, 1);
@@ -161,6 +183,10 @@ impl Layout {
                                 }
                             }
                         }
+
+                        if let Some(caps_sym) = xkb_state_caps.key_get_one_sym(kc).key_char() {
+                            caps_key.name = caps_sym.to_string();
+                        }
                     }
                     None => {
                         eprintln!("cannot find keycode for {:?} in keymap", key);
@@ -171,6 +197,7 @@ impl Layout {
                     "BKSL" => {
                         normal_key.width = 1.5;
                         shift_key.width = 1.5;
+                        caps_key.width = 1.5;
                         None
                     }
                     "BKSP" => Some(("Bksp", 2.0)),
@@ -197,16 +224,20 @@ impl Layout {
                     normal_key.width = width;
                     shift_key.name = name.to_string();
                     shift_key.width = width;
+                    caps_key.name = name.to_string();
+                    caps_key.width = width;
                 }
 
                 normal_row.push(normal_key);
                 shift_row.push(shift_key);
+                caps_row.push(caps_key);
             }
             normal_layer.rows.push(normal_row);
             shift_layer.rows.push(shift_row);
+            caps_layer.rows.push(caps_row);
         }
         Layout {
-            layers: vec![normal_layer, shift_layer],
+            layers: vec![normal_layer, shift_layer, caps_layer],
         }
     }
 }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -88,25 +88,11 @@ impl Layout {
             ],
         ];
 
-        // Create scratch xkb_state and update mask for Caps lock.
-        // This allows querying keysyms as if Caps lock is pressed.
-        let mut xkb_state_caps = xkb::State::new(keymap);
-        let caps_mask_filter = keymap
-            .mods()
-            .into_iter()
-            .filter(|v| *v == "Lock")
-            .collect::<Vec<&str>>();
-        let lock_modifier_name = caps_mask_filter.first();
-        let caps_mask = keymap.mod_get_index(lock_modifier_name.expect("Lock modifier should be present for keymap"));
-        xkb_state_caps.update_mask(0, 0, 1 << caps_mask, 0, 0, 0);
-
         let mut normal_layer = Layer::default();
         let mut shift_layer = Layer::default();
-        let mut caps_layer = Layer::default();
         for key_row in key_rows.iter() {
             let mut normal_row = Vec::with_capacity(key_row.len());
             let mut shift_row = Vec::with_capacity(key_row.len());
-            let mut caps_row = Vec::with_capacity(key_row.len());
             for &key in key_row.iter() {
                 let kind = match key {
                     // Press these modifiers until a normal key is pressed
@@ -147,18 +133,11 @@ impl Layout {
                     width: 1.0,
                     keycode: None,
                 };
-                let mut caps_key = Key {
-                    name: key.to_string(),
-                    kind,
-                    width: 1.0,
-                    keycode: None,
-                };
 
                 match keymap.key_by_name(key) {
                     Some(kc) => {
                         normal_key.keycode = Some(KeyCode(kc));
                         shift_key.keycode = Some(KeyCode(kc));
-                        caps_key.keycode = Some(KeyCode(kc));
 
                         let normal_syms = keymap.key_get_syms_by_level(kc, layout, 0);
                         if let Some(normal_sym) = normal_syms.get(0) {
@@ -171,7 +150,6 @@ impl Layout {
 
                             // Copy normal key name over by default
                             shift_key.name = normal_key.name.clone();
-                            caps_key.name = normal_key.name.clone();
                         }
 
                         let shift_syms = keymap.key_get_syms_by_level(kc, layout, 1);
@@ -183,10 +161,6 @@ impl Layout {
                                 }
                             }
                         }
-
-                        if let Some(caps_sym) = xkb_state_caps.key_get_one_sym(kc).key_char() {
-                            caps_key.name = caps_sym.to_string();
-                        }
                     }
                     None => {
                         eprintln!("cannot find keycode for {:?} in keymap", key);
@@ -197,7 +171,6 @@ impl Layout {
                     "BKSL" => {
                         normal_key.width = 1.5;
                         shift_key.width = 1.5;
-                        caps_key.width = 1.5;
                         None
                     }
                     "BKSP" => Some(("Bksp", 2.0)),
@@ -224,20 +197,16 @@ impl Layout {
                     normal_key.width = width;
                     shift_key.name = name.to_string();
                     shift_key.width = width;
-                    caps_key.name = name.to_string();
-                    caps_key.width = width;
                 }
 
                 normal_row.push(normal_key);
                 shift_row.push(shift_key);
-                caps_row.push(caps_key);
             }
             normal_layer.rows.push(normal_row);
             shift_layer.rows.push(shift_row);
-            caps_layer.rows.push(caps_row);
         }
         Layout {
-            layers: vec![normal_layer, shift_layer, caps_layer],
+            layers: vec![normal_layer, shift_layer],
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,7 +221,11 @@ impl Application for App {
                     xkb_state.mod_name_is_active(xkb::MOD_NAME_SHIFT, xkb::STATE_MODS_EFFECTIVE);
                 let caps =
                     xkb_state.mod_name_is_active(xkb::MOD_NAME_CAPS, xkb::STATE_MODS_EFFECTIVE);
-                self.layer = if shift != caps { 1 } else { 0 };
+                self.layer = match (shift, caps) {
+                    (true, false) => 1,
+                    (false, true) => 2,
+                    _ => 0,
+                };
             }
             Message::Quit => {
                 process::exit(0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,16 +216,18 @@ impl Application for App {
                         .expect("failed to flush EI connection");
                 }
 
-                //TODO: use xkb::State::key_get_level
-                let shift =
-                    xkb_state.mod_name_is_active(xkb::MOD_NAME_SHIFT, xkb::STATE_MODS_EFFECTIVE);
-                let caps =
-                    xkb_state.mod_name_is_active(xkb::MOD_NAME_CAPS, xkb::STATE_MODS_EFFECTIVE);
-                self.layer = match (shift, caps) {
-                    (true, false) => 1,
-                    (false, true) => 2,
-                    _ => 0,
-                };
+                let num_mods_active = xkb_state
+                    .get_keymap()
+                    .mods()
+                    .into_iter()
+                    .filter(|mod_name| {
+                        xkb_state.mod_name_is_active(mod_name, xkb::STATE_MODS_EFFECTIVE)
+                    })
+                    .count();
+
+                // layer[0]: base layer
+                // layer[1]: modifier layer
+                self.layer = if num_mods_active > 0 { 1 } else { 0 };
             }
             Message::Quit => {
                 process::exit(0);
@@ -302,9 +304,38 @@ impl Application for App {
                             });
                         }
                     }
-                    // TODO handle other modifiers
                     ei::Msg::Event(reis::event::EiEvent::KeyboardModifiers(evt)) => {
                         self.group = evt.group;
+                        if let Some(state) = &mut self.xkb_state {
+                            state.update_mask(evt.depressed, evt.latched, evt.locked, 0, 0, 0);
+
+                            // update the modifier layer's key names
+                            let layers: &mut Vec<layout::Layer> = self
+                                .layouts
+                                .as_mut()
+                                .unwrap()
+                                .first_mut()
+                                .unwrap()
+                                .layers
+                                .as_mut();
+                            let mod_layer = layers.get_mut(1).unwrap();
+                            let key_names_unchanged = &[
+                                "Bksp", "Del", "Caps", "Esc", "Alt", "Ctrl", "Shift", "Super",
+                                "PgDn", "PgUp", "Enter", " ", "Tab", "F1", "F2", "F3", "F4", "F5",
+                                "F6", "F7", "F8", "F9", "F10", "F11", "F12", "Home", "Up", "Left",
+                                "Down", "Up", "Right", "Insert", "End",
+                            ];
+                            for rows in mod_layer.rows.iter_mut() {
+                                for keycode in rows {
+                                    if !key_names_unchanged.contains(&keycode.name.as_ref()) {
+                                        let sym_new =
+                                            state.key_get_one_sym(keycode.keycode.unwrap().xkb());
+                                        let sym_new = xkb::keysym_to_utf8(sym_new);
+                                        keycode.name = sym_new.to_string();
+                                    }
+                                }
+                            }
+                        }
                     }
                     _ => {}
                 }


### PR DESCRIPTION
Relates to #15 

# Summary

Generate symbols when caps lock is pressed through a scratch `xkb_state`, applying `Lock` mask, querying syms for each keycode, and storing resulting symbols to a new layer for caps lock.

# Description

This is a different approach to what is being done for shift symbols which uses [`xkb::Keymap::get_key_syms_by_level`](https://docs.rs/xkbcommon/0.8.0/xkbcommon/xkb/struct.Keymap.html#method.key_get_syms_by_level) with a hardcoded shift level.

For caps lock, I couldn't find any suitable way to get the symbols from it, which is why I have tried this approach after looking through the docs.

# Notes
This probably isn't viable long-term. Pressing caps lock and then shift will give the wrong symbols. That can be solved with yet another `xkb_state` and mask, but that would get repetitive really quick.

Maybe, instead of caching all possibilities into a Layout, we can create on-the-fly when first requested, and store it to layers `Vec`? Perhaps that would let us work directly with the model field (`App.xkb_state`) if that updates realtime with OSK key presses.

---

I was looking to contribute. Opening this PR directly for discussion. Please close/draft if you find this not ready for review. I'm not well versed in XKB and this was my first time browsing through it.

If I missed part of a contribution process, please let me know.