### PR TITLE
Fix wrong height on start up and log spam

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,7 +209,8 @@ impl App {
     }
 
     pub fn show(&mut self) -> Task<Message> {
-        if self.surface_id.is_some() {
+        // Without layouts the surface would be created with height 0
+        if self.surface_id.is_some() || self.layouts.is_none() {
             return Task::none();
         }
 

--- a/src/wayland.rs
+++ b/src/wayland.rs
@@ -47,6 +47,7 @@ struct Seat {
     wl: WlSeat,
     im: Option<ZwpInputMethodV2>,
     im_active: bool,
+    im_active_sent: bool,
 }
 
 struct State {
@@ -78,6 +79,7 @@ impl Dispatch<wl_registry::WlRegistry, ()> for State {
                         wl: registry.bind(name, version, qh, name),
                         im: None,
                         im_active: false,
+                        im_active_sent: false,
                     },
                 );
             } else if interface == ZwpInputMethodManagerV2::interface().name {
@@ -148,16 +150,21 @@ impl Dispatch<ZwpInputMethodV2, u32> for State {
             Event::Deactivate => {
                 seat.im_active = false;
             }
-            Event::Done => futures::executor::block_on(async {
-                state
-                    .msg_tx
-                    .send(Message::SeatImActive {
-                        seat_id,
-                        active: seat.im_active,
-                    })
-                    .await
-            })
-            .expect("failed to send seat active event"),
+            // The compositor sends Done after every text_input commit
+            // Only forward on change.
+            Event::Done if seat.im_active != seat.im_active_sent => {
+                seat.im_active_sent = seat.im_active;
+                futures::executor::block_on(async {
+                    state
+                        .msg_tx
+                        .send(Message::SeatImActive {
+                            seat_id,
+                            active: seat.im_active,
+                        })
+                        .await
+                })
+                .expect("failed to send seat active event")
+            }
             //TODO: handle more events
             _ => {}
         }


### PR DESCRIPTION
- Alacritty sends a commit on any change (cursor blinking for example) that would cause the compositor to sends many Done events. OSK should only react on changes.
- and if layout is none, height would be 0 (compositor sets it to 1, but still wrong). We can `show()` later in keymap handler, so I think this is fine.